### PR TITLE
polyfill computedStyleMap on Element

### DIFF
--- a/src/utility/Elements.ts
+++ b/src/utility/Elements.ts
@@ -11,6 +11,19 @@ namespace Elements {
 		Define.set(Element.prototype, 'asType', function (this: Element, tagName): any {
 			return this.tagName.toLowerCase() === tagName ? this : undefined
 		})
+
+		if (!Element.prototype.computedStyleMap) { 
+			Define.set(Element.prototype, 'computedStyleMap', function (this: Element) {
+				const css = getComputedStyle(this)
+				return {
+					get (p: string) {
+						const v = css.getPropertyValue(p)
+						return v ? { toString: () => v } : undefined
+					},
+					// PUT OTHER METHODS DOWN HERE, only get() done for now because I can't find any uses of the other ones in the code
+				} as unknown as StylePropertyMapReadOnly
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
# remake of #79 because I messed it up

- Fallback to getComputedStyle().get() when computedStyleMap() is missing
- Tested on Firefox, Firefox Developer Edition, Chrome and Edge
- Only implements get() because that’s the only usage in the codebase atm as far as I know

## Small issues noticed
some minor things I thought looked a bit odd and might not have been intentional, i can make PRs if you're fine with that and if there's nothing more to them than on the surface

### Chrome
- hyperlinks do not wrap properly in popovers
  ![image](https://github.com/user-attachments/assets/eb88cd49-dfbb-475f-a96f-2384592fe3a4)
  (Applying `word-break: break-all;` to the hyperlink CSS should fix it, though there may be a deeper cause.)

### Firefox
- initially on firefox the popover was slightly transparent for me, then I inspect element removed the offending classes `transparent` and `transparent__popover-open__start` and it never happened for me again even after clearing cache. lemmino if you come across this
  ![image](https://github.com/user-attachments/assets/98e4f6b6-0874-458e-af7e-17c66f654640)
