### PR TITLE
Limit search input container width to 100%

### DIFF
--- a/style/component/search.chiri
+++ b/style/component/search.chiri
@@ -1,7 +1,7 @@
 .search:
 	%block
 	%relative
-	width: calc(#{content-width} + $app-column-width * 2)
+	width: min(calc(#{content-width} + $app-column-width * 2), 100%)
 	%margin-auto
 
 	&-icon:


### PR DESCRIPTION
Fixes search input taking up too much of the navbar